### PR TITLE
Reiwa support

### DIFF
--- a/kat
+++ b/kat
@@ -2,6 +2,7 @@
 
 # 日付部を作成
 year=$(date "+%Y年")
+date=$(date "+%m月%d日")
 while getopts ":-:" OPT; do
 	case $OPT in
 		-)
@@ -20,8 +21,7 @@ while getopts ":-:" OPT; do
 	esac
 
 done
-date=$(date "+${year}%m月%d日")
-body=\(${date}版\)
+body=\($year${date}版\)
 
 # ファイルの拡張子とそれ以外を抽出
 head=${1%%.*}
@@ -30,7 +30,7 @@ tail=${1#${1%%.*}}
 # 同一ディレクトリに同一日に取ったバックアップがある場合、時刻を追加
 if find "$(dirname "$1")" -name "$head$body$tail" | grep ".*"; then
 	# 日付部は変数dateに格納
-	body=\($date$(date "+%H時%M分%S秒")版\)
+	body=\($year$date$(date "+%H時%M分%S秒")版\)
 fi
 
 cp -pR "$1" "$head$body$tail"

--- a/kat
+++ b/kat
@@ -1,13 +1,31 @@
 #!/bin/sh
 
+# 日付部を作成
+year=$(date "+%Y年")
+while getopts ":-:" OPT; do
+    case $OPT in
+        -)
+            case $OPTARG in
+                reiwa)
+                    year=令和$(($(date "+%Y") - 2018))年
+                    ;;
+                *)
+                    ;;
+            esac
+            
+            shift
+            ;;
+        *)
+            ;;
+    esac
+    
+done
+date=$(date "+${year}%m月%d日")
+body=\(${date}版\)
+
 # ファイルの拡張子とそれ以外を抽出
 head=${1%%.*}
 tail=${1#${1%%.*}}
-
-# 日付部を作成
-year=$(date "+%Y年")
-date=$(date "+${year}%m月%d日")
-body=\(${date}版\)
 
 # 同一ディレクトリに同一日に取ったバックアップがある場合、時刻を追加
 if find "$(dirname "$1")" -name "$head$body$tail" | grep ".*"; then

--- a/kat
+++ b/kat
@@ -6,12 +6,13 @@ tail=${1#${1%%.*}}
 
 # 日付部を作成
 year=$(date "+%Y年")
-date=\($(date "+$year%m月%d日")版\)
+date=$(date "+${year}%m月%d日")
+body=\(${date}版\)
 
 # 同一ディレクトリに同一日に取ったバックアップがある場合、時刻を追加
-if find "$(dirname "$1")" -name "$head$date$tail" | grep ".*"; then
+if find "$(dirname "$1")" -name "$head$body$tail" | grep ".*"; then
     # 日付部は変数dateに格納
-    date=$(date "+(%Y年%m月%d日%H時%M分%S秒版)")
+    body=\($date$(date "+%H時%M分%S秒")版\)
 fi
 
-cp -pR "$1" "$head$date$tail"
+cp -pR "$1" "$head$body$tail"

--- a/kat
+++ b/kat
@@ -5,7 +5,10 @@ head=${1%%.*}
 tail=${1#${1%%.*}}
 # 同一ディレクトリに同一日に取ったバックアップがある場合、時刻を追加
 if find "$(dirname "$1")" -name "$head$(date "+(%Y年%m月%d日版)")$tail" | grep ".*"; then
-    cp -pR "$1" "${1%%.*}$(date "+(%Y年%m月%d日%H時%M分%S秒版)")${1#${1%%.*}}"
+    # 日付部は変数dateに格納
+    date=$(date "+(%Y年%m月%d日%H時%M分%S秒版)")
 else
-    cp -pR "$1" "${1%%.*}$(date "+(%Y年%m月%d日版)")${1#${1%%.*}}"
+    date=$(date "+(%Y年%m月%d日版)")
 fi
+
+cp -pR "$1" "$head$date$tail"

--- a/kat
+++ b/kat
@@ -3,12 +3,15 @@
 # ファイルの拡張子とそれ以外を抽出
 head=${1%%.*}
 tail=${1#${1%%.*}}
+
+# 日付部を作成
+year=$(date "+%Y年")
+date=\($(date "+$year%m月%d日")版\)
+
 # 同一ディレクトリに同一日に取ったバックアップがある場合、時刻を追加
-if find "$(dirname "$1")" -name "$head$(date "+(%Y年%m月%d日版)")$tail" | grep ".*"; then
+if find "$(dirname "$1")" -name "$head$date$tail" | grep ".*"; then
     # 日付部は変数dateに格納
     date=$(date "+(%Y年%m月%d日%H時%M分%S秒版)")
-else
-    date=$(date "+(%Y年%m月%d日版)")
 fi
 
 cp -pR "$1" "$head$date$tail"

--- a/kat
+++ b/kat
@@ -3,22 +3,22 @@
 # 日付部を作成
 year=$(date "+%Y年")
 while getopts ":-:" OPT; do
-    case $OPT in
-        -)
-            case $OPTARG in
-                reiwa)
-                    year=令和$(($(date "+%Y") - 2018))年
-                    ;;
-                *)
-                    ;;
-            esac
-            
-            shift
-            ;;
-        *)
-            ;;
-    esac
-    
+	case $OPT in
+		-)
+			case $OPTARG in
+				reiwa)
+					year=令和$(($(date "+%Y") - 2018))年
+					;;
+				*)
+					;;
+			esac
+
+			shift
+			;;
+		*)
+			;;
+	esac
+
 done
 date=$(date "+${year}%m月%d日")
 body=\(${date}版\)
@@ -29,8 +29,8 @@ tail=${1#${1%%.*}}
 
 # 同一ディレクトリに同一日に取ったバックアップがある場合、時刻を追加
 if find "$(dirname "$1")" -name "$head$body$tail" | grep ".*"; then
-    # 日付部は変数dateに格納
-    body=\($date$(date "+%H時%M分%S秒")版\)
+	# 日付部は変数dateに格納
+	body=\($date$(date "+%H時%M分%S秒")版\)
 fi
 
 cp -pR "$1" "$head$body$tail"

--- a/test.sh
+++ b/test.sh
@@ -20,10 +20,28 @@ fi
 
 ../kat kattest.fuga.hoge
 
-if find . | grep -E 'kattest\([0-9]+年[0-9]+月[0-9]+日[0-9]+時[0-9]+分[0-9]+秒版\).fuga.hoge'; then
+if find . | grep -E 'kattest\([0-9]+年[0-9]+月[0-9]+日[0-9]+時[0-9]+分[0-9]+秒版\).fuga.hoge' > /dev/null; then
   echo "kattest$(date "+(%Y年%m月%d日版)").fuga.hoge ok"
 else
   echo "kattest$(date "+(%Y年%m月%d日版)").fuga.hoge ng"
+  exit 1
+fi
+
+../kat --reiwa kattest.fuga.hoge
+
+if find . | grep -E 'kattest\(令和[0-9]+年[0-9]+月[0-9]+日版\).fuga.hoge' > /dev/null; then
+  echo "kattest.fuga.hoge 令和 ok"
+else
+  echo "kattest.fuga.hoge 令和 ng"
+  exit 1
+fi
+
+../kat --reiwa kattest.fuga.hoge
+
+if find . | grep -E 'kattest\(令和[0-9]+年[0-9]+月[0-9]+日[0-9]+時[0-9]+分[0-9]+秒版\).fuga.hoge' > /dev/null; then
+  echo "kattest$(date "+(%Y年%m月%d日版)").fuga.hoge 令和 ok"
+else
+  echo "kattest$(date "+(%Y年%m月%d日版)").fuga.hoge 令和 ng"
   exit 1
 fi
 
@@ -38,7 +56,7 @@ fi
 
 ../kat kattest
 
-if find . | grep -E 'kattest\([0-9]+年[0-9]+月[0-9]+日[0-9]+時[0-9]+分[0-9]+秒版\)'; then
+if find . | grep -E 'kattest\([0-9]+年[0-9]+月[0-9]+日[0-9]+時[0-9]+分[0-9]+秒版\)' > /dev/null; then
   echo "kattest$(date "+(%Y年%m月%d日版)") ok"
 else
   echo "kattest$(date "+(%Y年%m月%d日版)") ng"
@@ -56,7 +74,7 @@ fi
 
 ../kat kattest.piyo
 
-if find . | grep -E 'kattest\([0-9]+年[0-9]+月[0-9]+日[0-9]+時[0-9]+分[0-9]+秒版\).piyo'; then
+if find . | grep -E 'kattest\([0-9]+年[0-9]+月[0-9]+日[0-9]+時[0-9]+分[0-9]+秒版\).piyo' > /dev/null; then
   echo "kattest$(date "+(%Y年%m月%d日版)").piyo ok"
 else
   echo "kattest$(date "+(%Y年%m月%d日版)").piyo ng"


### PR DESCRIPTION
`--reiwa`をつけることで西暦ではなく令和で表示するように変更
- 注: ロングオプションをgetoptsで無理やり解析しているので今後思わぬ不具合がでることがあるかも

また令和オプション導入にあたってコード全体を見直し、少し構造を変更
具体的には
- ファイル名をheadに拡張子をtailに日付部をbodyに格納（変数）
- bodyはさらに年と月日（と時刻）に分かれそれぞれに値を格納してからbodyで連結
- `cp`をif文の外へ出しif文を簡略化

あと令和オプションのテストも適当に追加

Close #10 